### PR TITLE
add support for google realtime analytics API

### DIFF
--- a/lib/Net/Google/Analytics.pm
+++ b/lib/Net/Google/Analytics.pm
@@ -60,10 +60,20 @@ sub new_request {
     return Net::Google::Analytics::Request->new(@_);
 }
 
+sub new_realtime_request {
+    my $self = shift;
+
+    my %params = @_;
+    $params{realtime} = 1;
+
+    return Net::Google::Analytics::Request->new(%params);
+}
+
+
 sub _uri {
     my ($self, $req, $start_index, $max_results) = @_;
 
-    my $uri = URI->new('https://www.googleapis.com/analytics/v3/data/ga');
+    my $uri = URI->new(  'https://www.googleapis.com/analytics/v3/data/' . ( $req->realtime() ? 'realtime' : 'ga' ) );
     my @params;
     push(@params, 'start-index' => $start_index) if defined($start_index);
     push(@params, 'max-results' => $max_results) if defined($max_results);
@@ -304,6 +314,13 @@ Authenticate using a token returned from L<Net::Google::Analytics::OAuth2>.
     my $req = $analytics->new_request(param => $value, ...);
 
 Creates and returns a new L<Net::Google::Analytics::Request> object.
+
+=head2 new_realtime_request
+
+    my $req = $analytics->new_realtime_request(param => $value, ...);
+
+Creates and returns a new L<Net::Google::Analytics::Request> object, calling retrieve 
+on this request object will cause the request to use the google realtime analytics url.
 
 =head2 retrieve
 

--- a/lib/Net/Google/Analytics/Request.pm
+++ b/lib/Net/Google/Analytics/Request.pm
@@ -14,7 +14,7 @@ use Class::XSAccessor
         start_index max_results
         fields
         pretty_print
-        user_ip quota_user
+        user_ip quota_user realtime
     ) ],
     constructor => 'new';
 
@@ -30,13 +30,20 @@ my @param_map = (
     fields       => 'fields',
     pretty_print => 'prettyPrint',
     user_ip      => 'userIp',
-    quota_user   => 'quotaUser',
+    quota_user   => 'quotaUser'
 );
 
 sub _params {
     my $self = shift;
 
-    for my $name (qw(ids metrics start_date end_date)) {
+    my @required = qw(ids metrics);
+
+    unless ($self->{realtime})
+    {
+        @required = (qw( start_date end_date ), @required);
+    }
+
+    for my $name ( @required ) {
         my $value = $self->{$name};
         die("parameter $name is empty")
             if !defined($value) || $value eq '';

--- a/lib/Net/Google/Analytics/Response.pm
+++ b/lib/Net/Google/Analytics/Response.pm
@@ -61,7 +61,7 @@ sub _parse_json {
 sub _parse_column_name {
     my $name = shift;
 
-    my ($res) = $name =~ /^ga:(\w{1,64})\z/
+    my ($namespace, $res) = $name =~ /^(ga|rt):(\w{1,64})\z/
         or die("invalid column name: $name");
 
     # convert camel case

--- a/t/02-realtime.t
+++ b/t/02-realtime.t
@@ -1,0 +1,134 @@
+#!perl -w
+use strict;
+
+use Test::More qw/no_plan/;
+
+our $expect_url;
+our $content;
+
+sub get {
+    my ($self, $url, %params) = @_;
+
+    is($url, $expect_url, 'url');
+    is_deeply(
+        \%params,
+        {
+            'Auth-Test' => 'auth_value 123',
+        },
+        'auth_params',
+    );
+
+    return $self;
+}
+
+sub is_success      { return 1; }
+sub code            { return 200; }
+sub message         { return 'Success'; }
+sub decoded_content { return $content; }
+
+use_ok("Net::Google::Analytics");
+
+my $analytics = Net::Google::Analytics->new();
+ok($analytics, 'new');
+
+my $ua = $analytics->user_agent;
+ok($ua, 'get user_agent');
+
+$analytics->user_agent(__PACKAGE__);
+
+$analytics->auth_params('Auth-Test' => 'auth_value 123');
+
+my ($req, $res, $rows);
+
+$req = $analytics->new_realtime_request();
+$req->ids('ga:1234567');
+$req->dimensions('ga:pagePath');
+$req->metrics('ga:activeVisitors');
+$req->sort('-ga:activeVisitors');
+$req->max_results(5);
+
+$expect_url = 'https://www.googleapis.com/analytics/v3/data/realtime?ids=ga%3A1234567&metrics=ga%3AactiveVisitors&dimensions=ga%3ApagePath&sort=-ga%3AactiveVisitors&max-results=5';
+$content = <<'EOF';
+{
+    "totalsForAllResults" : {
+        "ga:activeVisitors" : "111022"
+    },
+        "query" : {
+            "sort" : [
+                "-ga:activeVisitors"
+            ],
+                "ids" : "ga:1234567",
+                "metrics" : [
+                    "ga:activeVisitors"
+            ],
+                "dimensions" : "ga:pagePath",
+                "max-results" : 5
+    },
+        "rows" : [
+            [
+                "/fdfds/dsffdsdfssfdsfdsfd",
+                "9948"
+            ],
+            [
+                "/jlllk/lkllll",
+                "7105"
+            ],
+            [
+                "/sdfsdsdfsdf/things-you-probably-didnt-know-about-disney-parks",
+                "4482"
+            ],
+            [
+                "/",
+                "4071"
+            ],
+            [
+                "/dsfsdfsdfsdfsd/things-that-happen-when-your-significant-other-is-out-of-tow?bffb=",
+                "3858"
+            ]
+    ],
+        "columnHeaders" : [{
+            "dataType" : "STRING",
+                "columnType" : "DIMENSION",
+                "name" : "rt:pagePath"
+        }, {
+            "dataType" : "INTEGER",
+                "columnType" : "METRIC",
+                "name" : "ga:activeVisitors"
+        }],
+        "kind" : "analytics#realtimeData",
+        "selfLink" : "https://www.googleapis.com/analytics/v3/data/realtime?ids=ga:1234567&dimensions=ga:pagePath&metrics=ga:activeVisitors&sort=-ga:activeVisitors&max-results=5",
+        "profileInfo" : {
+            "tableId" : "realtime:1234567",
+                "accountId" : "1740781",
+                "profileId" : "1234567",
+                "profileName" : "buzzfeed.com",
+                "internalWebPropertyId" : "3070405",
+                "webPropertyId" : "UA-1740781-1"
+    },
+        "id" : "https://www.googleapis.com/analytics/v3/data/realtime?ids=ga:1234567&dimensions=ga:pagePath&metrics=ga:activeVisitors&sort=-ga:activeVisitors&max-results=5",
+        "totalResults" : 6937
+}
+EOF
+
+$res = $analytics->retrieve($req);
+ok($res, 'retrieve data');
+ok($res->is_success, 'retrieve success');
+
+is($res->num_rows, 5, 'num_rows');
+is($res->total_results, 6937, 'total_results');
+ok(!$res->contains_sampled_data, 'contains_sampled_data');
+
+my $column_headers = $res->_column_headers;
+ok($column_headers, 'column headers');
+is($column_headers->[0]->{name}, 'page_path');
+
+my @metrics = $res->metrics;
+is_deeply(\@metrics, [ qw(active_visitors) ]);
+
+my @dimensions = $res->dimensions;
+is_deeply(\@dimensions, [ qw(page_path) ]);
+
+$rows = $res->rows;
+ok($rows, 'rows');
+is(@$rows, 5, 'count rows');
+


### PR DESCRIPTION
Adds support for the Realtime Reporting API as described here: https://developers.google.com/analytics/devguides/reporting/realtime/v3/reference/data/realtime/get#try-it

Changes here are to add a new_realtime_request method and based on this:

- Change request base uri for the realtime endpoint
- Do not enforce start_date/end_date as required params on realtime requests
- Allow the rt: namespace for response columns in additing to ga:

I would love to get this back to CPAN if possible, it would make our production deployment a lot simpler.

Thanks,
Andy