### PR TITLE
Update dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,7 @@ Class::XSAccessor = 1.05
 JSON = 0
 LWP::UserAgent = 0
 URI = 0
+LWP::Protocol::https = 0
 
 [MetaResources]
 repository = http://github.com/nwellnhof/Net-Google-Analytics


### PR DESCRIPTION
Add missing dependency.

```
error getting token: 501 Protocol scheme 'https' is not supported (LWP::Protocol::https not installed) at /usr/local/share/perl/5.10.1/Net/Google/Analytics/OAuth2.pm line 69.
```
