### PR TITLE
Fixed method names from getting double underscore. eg: get__users

### DIFF
--- a/lib/Net/Google/Analytics/Response.pm
+++ b/lib/Net/Google/Analytics/Response.pm
@@ -66,6 +66,9 @@ sub _parse_column_name {
     my ($res) = $name =~ /^(?:ga|rt):(\w{1,64})\z/
         or die("invalid column name: $name");
 
+    # lc first letter so we don't add _ in front when we convert to camel case
+    $res = lc($1) . $2 if $res =~ /^([A-Z])(.*)/;
+    
     # convert camel case
     $res =~ s/[A-Z]/'_' . lc($&)/ge;
 


### PR DESCRIPTION
There was a bug with the method name getting double underscore when the first letter of the column name was in upper case. For example when the column name was 'ga:Users' the method name getting generated was 'get__users'.